### PR TITLE
chore: add pyproject metadata and READMEs

### DIFF
--- a/DSPY_Dev_Assistant/assistant/README.md
+++ b/DSPY_Dev_Assistant/assistant/README.md
@@ -1,0 +1,20 @@
+# assistant – Purpose
+
+## About
+Modules and signature definitions for the DSPy Developer Assistant. These components implement the assistant's reasoning and verification capabilities.
+
+## Contents
+- `modules.py` – DSPy modules composing the assistant's workflow.
+- `signatures.py` – Pydantic-based schemas describing module inputs and outputs.
+
+## How to Use
+Imported by `../main.py` to construct the complete assistant. Extend these modules to add new capabilities or modify behavior.
+
+## Development Notes
+Depends on `dspy` and `pydantic` for schema validation.
+
+## Related Links
+- Parent project README at `../README.md`
+
+## Status/TODO
+Future work includes additional modules for documentation retrieval and code execution.

--- a/DSPY_Dev_Assistant/data/README.md
+++ b/DSPY_Dev_Assistant/data/README.md
@@ -1,0 +1,19 @@
+# data – Purpose
+
+## About
+Training examples used to bootstrap the DSPy Developer Assistant.
+
+## Contents
+- `trainset.py` – returns a small set of input/output pairs for compilation.
+
+## How to Use
+Imported by `../main.py` when compiling the assistant with `BootstrapFewShot`.
+
+## Development Notes
+The current dataset is minimal; expand with additional examples to improve robustness.
+
+## Related Links
+- Parent project README at `../README.md`
+
+## Status/TODO
+Consider externalizing data into JSON or YAML for easier editing.

--- a/DSPY_Dev_Assistant/templates/README.md
+++ b/DSPY_Dev_Assistant/templates/README.md
@@ -1,0 +1,19 @@
+# templates – Purpose
+
+## About
+HTML templates for the Developer Assistant's optional web interface.
+
+## Contents
+- `index.html` – basic Jinja2 template used to render the assistant UI.
+
+## How to Use
+Served by a web framework (e.g., FastAPI) when building a front-end for the assistant.
+
+## Development Notes
+Templates assume Jinja2 rendering; adjust if switching frameworks.
+
+## Related Links
+- Parent project README at `../README.md`
+
+## Status/TODO
+Layout and styling are minimal and can be improved.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# DSPy Workspace – Purpose
+
+## About
+This repository collects experiments, utilities, and tutorials built around the [DSPy](https://github.com/stanfordnlp/dspy) framework.  It bundles small applications, configuration examples for different LLM backends, and educational notebooks demonstrating how to compose DSPy programs.
+
+## Contents
+- `DSPY_Dev_Assistant/` – self-correcting developer assistant prototype.
+- `llmtxt_generator/` – scripts and web UI to generate `llms.txt` descriptors for GitHub projects.
+- `codeGeneration_for_unfamilar_libraries/` – interactive helper for exploring new Python libraries.
+- `ollama-llm_config/` & `vllm-llm_config/` – configuration templates for different serving stacks.
+- `tutorials/` – example agents and utilities showing DSPy usage.
+- `scripts/` – helper shell scripts for environment setup and MLflow.
+
+## How to Use
+Each module is largely self-contained. Install dependencies with `pip install -e .[dev,web]` and run the scripts directly, e.g. `python generate_llms.py --repo <URL>`.  The `llmtxt_generator/web_interface.py` script can be started with `uvicorn llmtxt_generator.web_interface:app` for a simple UI.
+
+## Development Notes
+- Requires Python 3.9+.
+- Linting is configured with [Ruff](https://ruff.rs/).
+- Tests are executed via `pytest` (no tests are currently included).
+
+## Related Links
+- [DSPy documentation](https://dspy.ai)
+
+## Status/TODO
+This workspace is experimental and lacks packaging metadata such as license, author and project URLs.  Contributions are welcome.

--- a/codeGeneration_for_unfamilar_libraries/README.md
+++ b/codeGeneration_for_unfamilar_libraries/README.md
@@ -1,0 +1,23 @@
+# codeGeneration_for_unfamilar_libraries – Purpose
+
+## About
+Utilities for exploring and learning the APIs of unfamiliar Python libraries using DSPy-driven agents.  The tools scrape documentation and generate example code to accelerate onboarding.
+
+## Contents
+- `main.py` – orchestrates the learning workflow and produces summaries.
+- `interactive_learning.py` – CLI for iteratively querying a library.
+- `learn_library.py` – helper functions used during exploration.
+- `generate_examples.py` – builds code snippets from discovered APIs.
+- `repo_helpers.py` – common routines for gathering repository metadata.
+
+## How to Use
+Run `python main.py --library <name>` to generate a quick reference for a new package, or launch `interactive_learning.py` to engage in a question–answer session about the library.
+
+## Development Notes
+Requires network access for documentation scraping. Ensure environment variables required by `python-dotenv` are configured.
+
+## Related Links
+- [DSPy](https://dspy.ai)
+
+## Status/TODO
+Additional tests and error handling are planned.

--- a/llmtxt_generator/README.md
+++ b/llmtxt_generator/README.md
@@ -1,1 +1,24 @@
-# llmtxt_generator
+# llmtxt_generator – Purpose
+
+## About
+Tools for generating `llms.txt` metadata files describing repositories for LLM context ingestion. Includes both command-line utilities and a small web interface built with FastAPI.
+
+## Contents
+- `generate_llms.py` – single-repo generator script.
+- `multiple-repo_llmstxt.py` – process many repositories sequentially.
+- `repository_analyzer.py` & `repo_helpers.py` – analyze repository structure and README content.
+- `signatures.py` – DSPy signature definitions for the analyzer.
+- `web_interface.py` – FastAPI app providing a simple form-based UI.
+- `templates/` – Jinja2 templates used by the web app.
+
+## How to Use
+Run `python generate_llms.py --repo <URL>` for a single project or `python multiple-repo_llmstxt.py --file list.txt` to batch process. Launch the web interface with `uvicorn llmtxt_generator.web_interface:app`.
+
+## Development Notes
+Requires DSPy, `requests`, `python-dotenv`, and `fastapi` with `uvicorn` for the web UI.
+
+## Related Links
+- [DSPy documentation](https://dspy.ai)
+
+## Status/TODO
+Error handling and unit tests are minimal and should be expanded.

--- a/llmtxt_generator/templates/README.md
+++ b/llmtxt_generator/templates/README.md
@@ -1,0 +1,19 @@
+# templates – Purpose
+
+## About
+Templates for the `llmtxt_generator` web interface.
+
+## Contents
+- `index.html` – Jinja2 template rendering the repository input form and results.
+
+## How to Use
+Used by `web_interface.py` when served through FastAPI and Jinja2.
+
+## Development Notes
+Customize this template to change the look and feel of the web UI.
+
+## Related Links
+- Parent project README at `../README.md`
+
+## Status/TODO
+Styling is minimal; contributions welcome.

--- a/ollama-llm_config/README.md
+++ b/ollama-llm_config/README.md
@@ -1,0 +1,23 @@
+# ollama-llm_config – Purpose
+
+## About
+Configuration files and scripts for experimenting with DSPy using the [Ollama](https://ollama.com/) local LLM server.  They mirror the generic library-learning utilities with settings tailored for the Ollama backend.
+
+## Contents
+- `main.py` – entry point for generating library summaries.
+- `interactive_learning.py` & `learn_library.py` – interactive exploration helpers.
+- `generate_examples.py` – produce sample code from learned APIs.
+- `repo_helpers.py` – common repository utilities.
+- `litellm_learning.json` / `vllm_learning.json` – example model configurations.
+
+## How to Use
+Ensure an Ollama server is running, then execute `python main.py --library <name>` to query a library using the configured models.  Adjust the JSON configs to swap models or parameters.
+
+## Development Notes
+Relies on `requests`, `html2text`, and `python-dotenv` for HTTP access and environment management.
+
+## Related Links
+- [Ollama project](https://ollama.com)
+
+## Status/TODO
+Configuration files are samples; adapt them for your environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "dspy-workspace"
+version = "0.1.0"
+urls = {"Homepage" = "TBD", "Repository" = "TBD"}
+description = "Collection of DSPy-based tools, configs, and tutorials"
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "TBD"}
+authors = [{name = "TBD"}]
+dependencies = [
+  "dspy",
+  "requests",
+  "python-dotenv",
+  "beautifulsoup4",
+  "html2text",
+  "pydantic",
+]
+
+[project.optional-dependencies]
+web = [
+  "fastapi",
+  "uvicorn",
+]
+dev = [
+  "mlflow",
+  "openai",
+  "litellm[proxy]",
+  "vllm",
+  "datasets<4.0.0",
+  "ollama",
+  "orjson",
+]
+
+[tool.hatch.build]
+include = [
+  "*.py",
+  "*/**/*.py",
+  "*/**/*.html",
+]
+
+[tool.ruff]
+select = ["E", "F"]
+target-version = "py39"
+
+[tool.pytest.ini_options]
+addopts = "-ra"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,21 @@
+# scripts – Purpose
+
+## About
+Helper shell scripts for managing local development environments and MLflow tracking.
+
+## Contents
+- `activate_env.sh` – activate the Python virtual environment for this workspace.
+- `start_mlflow.sh` – launch an MLflow tracking server on port 5000.
+- `push.sh` – convenience wrapper for committing and pushing changes.
+
+## How to Use
+Run the scripts directly from the repository root, e.g. `bash scripts/start_mlflow.sh` to start MLflow.
+
+## Development Notes
+Ensure executable permissions are preserved when modifying these files (`chmod +x`).
+
+## Related Links
+- [MLflow documentation](https://mlflow.org)
+
+## Status/TODO
+Scripts are minimal and may require adaptation for different environments.

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,0 +1,21 @@
+# tutorials – Purpose
+
+## About
+Sample projects demonstrating DSPy concepts, including agent construction, conversation history management, and automatic `llms.txt` generation for multiple repositories.
+
+## Contents
+- `agents/` – full ReAct agent example with training and evaluation scripts.
+- `conversation_history/` – minimal demo showing how to persist dialogue state.
+- `multi-llmtxt_generator/` – batch utility for creating `llms.txt` files across repositories.
+
+## How to Use
+Enter a subdirectory and follow its README for environment setup and execution commands. Each tutorial is independent.
+
+## Development Notes
+Tutorial code depends on optional packages such as `mlflow` and `datasets`; install extras with `pip install -e .[dev]` if needed.
+
+## Related Links
+- [DSPy tutorial documentation](https://dspy.ai)
+
+## Status/TODO
+Additional tutorials and comprehensive tests may be added in the future.

--- a/tutorials/agents/agent/README.md
+++ b/tutorials/agents/agent/README.md
@@ -1,0 +1,19 @@
+# agent – Purpose
+
+## About
+Defines the ReAct-style agent used in the tutorial. The agent combines reasoning steps with tool usage to answer multi-hop questions.
+
+## Contents
+- `react_agent.py` – constructs and returns a configured DSPy agent.
+
+## How to Use
+Call `create_react_agent()` from this module to obtain an agent instance for training or evaluation.
+
+## Development Notes
+The agent depends on tool functions (e.g., Wikipedia search) residing in `../tools`.
+
+## Related Links
+- [ReAct paper](https://arxiv.org/abs/2210.03629)
+
+## Status/TODO
+Future versions may expose additional configuration options and support more tools.

--- a/tutorials/agents/config/README.md
+++ b/tutorials/agents/config/README.md
@@ -1,0 +1,19 @@
+# config – Purpose
+
+## About
+Holds configuration utilities for the tutorial's agent, primarily model selection and initialization.
+
+## Contents
+- `models.py` – defines `setup_models()` which configures the language models used during training and evaluation.
+
+## How to Use
+Import `setup_models` to obtain model instances tailored for your hardware or API endpoints.
+
+## Development Notes
+The default configuration targets local models via LiteLLM; adjust to suit your environment.
+
+## Related Links
+- [LiteLLM](https://github.com/BerriAI/litellm)
+
+## Status/TODO
+Consider adding YAML-based configuration for easier customization.

--- a/tutorials/agents/data/README.md
+++ b/tutorials/agents/data/README.md
@@ -1,0 +1,19 @@
+# data – Purpose
+
+## About
+Contains dataset utilities for the DSPy ReAct agent tutorial. Currently includes a loader for the HoVer question-answering dataset.
+
+## Contents
+- `hover_loader.py` – fetches and formats HoVer examples using `dspy.datasets`.
+
+## How to Use
+Import `load_hover_data` from this module within training or evaluation scripts to obtain prepared datasets.
+
+## Development Notes
+Requires the `datasets` package (<4.0.0) and network access to download data.
+
+## Related Links
+- [HoVer dataset](https://hover-nlp.github.io/)
+
+## Status/TODO
+Extend with additional dataset loaders as tutorials expand.

--- a/tutorials/agents/evaluation/README.md
+++ b/tutorials/agents/evaluation/README.md
@@ -1,0 +1,19 @@
+# evaluation – Purpose
+
+## About
+Provides evaluation metrics for the tutorial agent.
+
+## Contents
+- `metrics.py` – implements `top5_recall` for measuring retrieval quality.
+
+## How to Use
+Import `top5_recall` in evaluation scripts to compute recall@5 for model predictions.
+
+## Development Notes
+Depends only on `dspy` and the Python standard library.
+
+## Related Links
+- [DSPy evaluation guide](https://dspy.ai)
+
+## Status/TODO
+Additional metrics and logging hooks may be added.

--- a/tutorials/agents/tools/README.md
+++ b/tutorials/agents/tools/README.md
@@ -1,0 +1,19 @@
+# tools – Purpose
+
+## About
+Holds external helper utilities used by the tutorial agent. These tools provide an interface between the agent and external knowledge sources.
+
+## Contents
+- `wikipedia.py` – simple wrapper around Wikipedia search and lookup functions.
+
+## How to Use
+Import `search_wikipedia` or `lookup_wikipedia` into DSPy modules to enable web-assisted reasoning.
+
+## Development Notes
+Internet access is required for live queries. Consider caching results for reproducibility.
+
+## Related Links
+- [Wikipedia API](https://www.mediawiki.org/wiki/API:Main_page)
+
+## Status/TODO
+Additional tools (e.g., calculators, code runners) can be added as the tutorial evolves.

--- a/tutorials/conversation_history/README.md
+++ b/tutorials/conversation_history/README.md
@@ -1,0 +1,19 @@
+# conversation_history – Purpose
+
+## About
+Demonstrates storing and replaying chat history within a DSPy program. Useful for building stateful assistants that recall prior exchanges.
+
+## Contents
+- `main.py` – example script persisting a simple conversation to disk.
+
+## How to Use
+Run `python main.py` to generate a conversation log and verify that past messages are retained between runs.
+
+## Development Notes
+The example is intentionally minimal and relies only on `dspy` and the standard library.
+
+## Related Links
+- [DSPy documentation](https://dspy.ai)
+
+## Status/TODO
+Consider expanding to cover database-backed history storage.

--- a/tutorials/multi-llmtxt_generator/README.md
+++ b/tutorials/multi-llmtxt_generator/README.md
@@ -1,0 +1,22 @@
+# multi-llmtxt_generator – Purpose
+
+## About
+Batch-processing utility for generating `llms.txt` descriptors for multiple GitHub repositories at once.  Extends the single-repo generator with iteration and optional interactive mode.
+
+## Contents
+- `generate_llms.py` – core batch generation script.
+- `interactive_generate_llms.py` – interactive CLI for reviewing each repo.
+- `repository_analyzer.py` & `repo_helpers.py` – helper modules for repository analysis.
+- `signatures.py` – DSPy signature definitions used by the analyzer.
+
+## How to Use
+Provide a list of repository URLs to `generate_llms.py` or use the interactive script to step through one at a time. Results are written to per-repo `llms.txt` files.
+
+## Development Notes
+Requires network connectivity and a configured language model backend accessible via DSPy.
+
+## Related Links
+- [Single-repo generator](../../llmtxt_generator)
+
+## Status/TODO
+Support for parallel processing and richer error reporting is a future enhancement.

--- a/vllm-llm_config/README.md
+++ b/vllm-llm_config/README.md
@@ -1,0 +1,23 @@
+# vllm-llm_config – Purpose
+
+## About
+Example scripts and settings for running the library-learning workflow against [vLLM](https://github.com/vllm-project/vllm) servers.  The layout mirrors the Ollama configuration but targets the vLLM API.
+
+## Contents
+- `main.py` – drives the learning and summarization process.
+- `interactive_learning.py` & `learn_library.py` – support scripts for conversational exploration.
+- `generate_examples.py` – generate code samples from inferred APIs.
+- `repo_helpers.py` – shared repository utilities.
+- `litellm_learning.json` – sample model configuration.
+
+## How to Use
+Deploy a vLLM server and run `python main.py --library <name>` to explore a library.  Modify the JSON config to select different models or endpoints.
+
+## Development Notes
+Assumes the same Python dependencies as the base library-learning utilities (`requests`, `bs4`, `html2text`, etc.).
+
+## Related Links
+- [vLLM project](https://github.com/vllm-project/vllm)
+
+## Status/TODO
+Currently provided as a template; extend with real model settings as needed.


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with hatchling build config, dependencies, and tooling stubs
- document root and subdirectories with README files
- set up basic ruff and pytest settings

## Testing
- `ruff check .` *(fails: numerous style errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c708630944832891d429e718c33cf8