### PR TITLE
Add linter config and Ollama cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dev = [
   "datasets<4.0.0",
   "ollama",
   "orjson",
+  "pre-commit",
+  "ruff",
+  "pytest",
 ]
 
 [tool.hatch.build]
@@ -43,8 +46,11 @@ include = [
 ]
 
 [tool.ruff]
-select = ["E", "F"]
+line-length = 88
 target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B"]
 
 [tool.pytest.ini_options]
 addopts = "-ra"

--- a/tests/test_interactive_generate_llms.py
+++ b/tests/test_interactive_generate_llms.py
@@ -1,0 +1,46 @@
+import importlib.util
+import pathlib
+import subprocess
+import sys
+import types
+
+MODULE_PATH = (
+    pathlib.Path(__file__).parent.parent
+    / "tutorials"
+    / "multi-llmtxt_generator"
+    / "interactive_generate_llms.py"
+)
+
+# Stub out helper modules expected by the script so it imports cleanly.
+dummymod = types.ModuleType("repo_helpers")
+dummymod.gather_repository_info = lambda _: ([], "", [])
+sys.modules["repo_helpers"] = dummymod
+sys.modules["fixed_repo_helpers"] = dummymod
+
+spec = importlib.util.spec_from_file_location("interactive_generate_llms", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+assert spec and spec.loader
+spec.loader.exec_module(module)  # type: ignore[attr-defined]
+stop_ollama_model = module.stop_ollama_model
+
+
+def test_stop_ollama_model_calls_subprocess_run(monkeypatch):
+    called = {}
+
+    def fake_run(cmd, check, capture_output):
+        called["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    stop_ollama_model("test-model")
+    assert called["cmd"] == ["ollama", "stop", "test-model"]
+
+
+def test_stop_ollama_model_handles_error(monkeypatch, capsys):
+    def fake_run(cmd, check, capture_output):
+        raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    stop_ollama_model("bad-model")
+    out = capsys.readouterr().out
+    assert "Failed to stop model bad-model" in out

--- a/tutorials/multi-llmtxt_generator/interactive_generate_llms.py
+++ b/tutorials/multi-llmtxt_generator/interactive_generate_llms.py
@@ -1,8 +1,10 @@
 # interactive_generate_llms.py — prompt user for a valid GitHub URL
 import argparse
 import re
-from dotenv import load_dotenv
+import subprocess
+
 import dspy
+from dotenv import load_dotenv
 
 # Prefer the user's local helpers if present; fall back to fixed helpers.
 try:
@@ -12,8 +14,12 @@ except Exception:
 
 load_dotenv()
 
-HTTPS_RE = re.compile(r"^https?://github\.com/([^/]+)/([^/]+?)(?:\.git)?(?:/.*)?$", re.IGNORECASE)
+HTTPS_RE = re.compile(
+    r"^https?://github\.com/([^/]+)/([^/]+?)(?:\.git)?(?:/.*)?$", re.IGNORECASE
+)
 SSH_RE = re.compile(r"^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$", re.IGNORECASE)
+MODEL_NAME = "hf.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:IQ2_XXS"
+
 
 def normalize_repo_url(url: str) -> str:
     """Accept common GitHub URL forms and normalize to https form.
@@ -35,26 +41,31 @@ def normalize_repo_url(url: str) -> str:
     if m:
         owner, repo = m.group(1), m.group(2)
         return f"https://github.com/{owner}/{repo}"
-    raise ValueError("Invalid GitHub URL. Expected https://github.com/<owner>/<repo> or git@github.com:owner/repo.git")
+    raise ValueError(
+        "Invalid GitHub URL. Expected https://github.com/<owner>/<repo> "
+        "or git@github.com:owner/repo.git"
+    )
 
 
 def prompt_for_repo_url() -> str:
     while True:
         try:
-            raw = input("Enter GitHub repo URL (e.g., https://github.com/<owner>/<repo>): ").strip()
+            raw = input(
+                "Enter GitHub repo URL (e.g., https://github.com/<owner>/<repo>): "
+            ).strip()
             normalized = normalize_repo_url(raw)
             return normalized
         except ValueError as e:
             print(f"\n{e}\nPlease try again.\n")
         except KeyboardInterrupt:
             print("\nCanceled by user.")
-            raise SystemExit(1)
+            raise SystemExit(1) from None
 
 
 def generate_llms_txt_for_dspy(repo_url: str):
     # Correct Ollama LM initialization
     lm = dspy.LM(
-        "ollama_chat/hf.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:IQ2_XXS",
+        f"ollama_chat/{MODEL_NAME}",
         api_base="http://localhost:11434",
         api_key="",
         streaming=False,
@@ -63,7 +74,11 @@ def generate_llms_txt_for_dspy(repo_url: str):
     dspy.configure(lm=lm)
 
     file_tree, readme_content, package_files = gather_repository_info(repo_url)
-    from repository_analyzer import RepositoryAnalyzer  # Local import so script still works without analyzer until used
+    from repository_analyzer import (
+        # Local import so script still works without analyzer until used
+        RepositoryAnalyzer,
+    )
+
     analyzer = RepositoryAnalyzer()
     result = analyzer(
         repo_url=repo_url,
@@ -74,9 +89,25 @@ def generate_llms_txt_for_dspy(repo_url: str):
     return result
 
 
+def stop_ollama_model(model_name: str) -> None:
+    """Stop the specified Ollama model to free server resources."""
+    try:
+        subprocess.run(
+            ["ollama", "stop", model_name],
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - log warning only
+        print(f"Warning: Failed to stop model {model_name}: {exc}")
+
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Generate llms.txt for a GitHub repo (interactive-friendly)")
-    parser.add_argument("--repo", help="GitHub repo URL (https://github.com/<owner>/<repo>)")
+    parser = argparse.ArgumentParser(
+        description="Generate llms.txt for a GitHub repo (interactive-friendly)"
+    )
+    parser.add_argument(
+        "--repo", help="GitHub repo URL (https://github.com/<owner>/<repo>)"
+    )
     args = parser.parse_args()
 
     repo_url = None
@@ -94,3 +125,4 @@ if __name__ == "__main__":
         f.write(result.llms_txt_content)
     print("Generated llms.txt file!\nPreview:\n")
     print(result.llms_txt_content[:500] + "...")
+    stop_ollama_model(MODEL_NAME)


### PR DESCRIPTION
## Summary
- add project-wide pre-commit with Ruff
- expand Ruff settings and dev dependencies
- stop Ollama model after generating llms.txt and test cleanup logic

## Testing
- `pre-commit run --files tutorials/multi-llmtxt_generator/interactive_generate_llms.py tests/test_interactive_generate_llms.py pyproject.toml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c71795d11083289d97148a58666a02